### PR TITLE
Update .gitignore to exclude development artifacts (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,11 @@ temp/
 dist/
 build/
 gotodo
+main
 
-# Air live reload tool
+# Air live reload tool and config
 tmp/
+.air.toml
+
+# Development directories
+.serena/


### PR DESCRIPTION
## Summary
- Add main binary to ignore list to prevent committing compiled Go executables
- Add .air.toml configuration file used by Air hot reload tool
- Add .serena/ development directory to ignore list

## Test plan
- [x] Verified no development artifacts are tracked in git status
- [x] Confirmed .gitignore properly excludes build outputs and dev tools

🤖 Generated with [Claude Code](https://claude.ai/code)